### PR TITLE
Adds the option for multiple named auth options

### DIFF
--- a/functions/cfc-nanny-auth/lambda_function.py
+++ b/functions/cfc-nanny-auth/lambda_function.py
@@ -21,7 +21,7 @@ def get_allowed_keys(route):
         return None
 
     allowed_keys = set()
-    allowed_key_names = auth_keys.split(",")
+    allowed_key_names = allowed_keys.split(",")
     for key_name in allowed_key_names:
         key = os.getenv(key_name)
 

--- a/functions/cfc-nanny-auth/lambda_function.py
+++ b/functions/cfc-nanny-auth/lambda_function.py
@@ -1,13 +1,6 @@
 import json
 import os
 
-def get_expected_auth(route):
-    route = route.replace("/", "")
-    route = route.replace("-", "_")
-    route = route.upper()
-    
-    return os.environ.get("{}_AUTH".format(route), None)
-
 def is_authorized(authorized):
     return { "isAuthorized": authorized }
 
@@ -17,31 +10,52 @@ def deny():
 def accept():
     return is_authorized(True)
 
+def get_allowed_keys(route):
+    route = route.replace("/", "")
+    route = route.replace("-", "_")
+    route = route.upper()
+
+    allowed_key_names = os.environ.get("{}_AUTH".format(route), None)
+
+    if not allowed_key_names:
+        return None
+
+    allowed_keys = set()
+    allowed_key_names = auth_keys.split(",")
+    for key_name in allowed_key_names:
+        key = os.environ.get(key_name, None)
+
+        if not key:
+            print("Erorr! Couldn't find key in environment: {}".format(key_name))
+            continue
+
+        allowed_keys.add(key)
+
+    return allowed_keys
+
 def lambda_handler(event, context):
-    auth = event.get("headers", {}).get("authorization", None)
-    
-    if auth is None:
+    key = event.get("headers", {}).get("authorization", None)
+
+    if key is None:
         print("Auth is none, returning False")
         return deny()
-        
+
     route = event.get("rawPath", None)
-    
+
     if route is None:
         print("Route is none, returning False")
         return deny()
 
-    expected = get_expected_auth(route)
-    
-    if expected is None:
-        print("Route not present in AUTH, returning False")
-        return deny()
-        
-    print("{} == {} = {}".format(auth, expected, auth == expected))
+    allowed_keys = get_allowed_keys(route)
 
-    is_authorized = auth == expected
-    
+    if allowed_keys is None:
+        print("Couldn't find any allowed keys for given route, '{}'. Denying.".format(route))
+        return deny()
+
+    is_authorized = key in allowed_keys
+
     if is_authorized:
         return accept()
-    
+
     return deny()
 

--- a/functions/cfc-nanny-auth/lambda_function.py
+++ b/functions/cfc-nanny-auth/lambda_function.py
@@ -15,7 +15,7 @@ def get_allowed_keys(route):
     route = route.replace("-", "_")
     route = route.upper()
 
-    allowed_key_names = os.environ.get("{}_AUTH".format(route), None)
+    allowed_key_names = os.getenv(f"{route}_AUTH")
 
     if not allowed_key_names:
         return None
@@ -23,10 +23,10 @@ def get_allowed_keys(route):
     allowed_keys = set()
     allowed_key_names = auth_keys.split(",")
     for key_name in allowed_key_names:
-        key = os.environ.get(key_name, None)
+        key = os.getenv(key_name)
 
         if not key:
-            print("Erorr! Couldn't find key in environment: {}".format(key_name))
+            print(f"Warning! Couldn't find key in environment: {key_name}")
             continue
 
         allowed_keys.add(key)
@@ -58,4 +58,3 @@ def lambda_handler(event, context):
         return accept()
 
     return deny()
-


### PR DESCRIPTION
The `CFC3_RESTART_AUTH` variable will now be something like: `CFC3_GLUA,RCON_BACKEND,CFC_DISCORD_BOT` and so forth.
Then you'd just define each of those in the environment variables and you're good to go.

If we rapidly need to disable a compromised key, we can simply remove the environment variable (and then update the `CFC3_RESTART_AUTH` key when convenient).